### PR TITLE
Fixed crash on error reporting

### DIFF
--- a/src/main/webapp/walldisplay.js
+++ b/src/main/webapp/walldisplay.js
@@ -529,7 +529,7 @@ function getJobs(jobList){
                                 updateRunningJobs[jobInfo.name] = false;
                             },
                             error: function(e, xhr){
-                                debug("error getting api for job '" + jobName + "': '" + e.statusText + "'");
+                                debug("error getting api for job '" + jobInfo.name + "': '" + e.statusText + "'");
                                 updateRunningJobs[jobInfo.name] = false;
                             },
                             timeout: jenkinsTimeOut


### PR DESCRIPTION
"jobName" varialble is undefined. "jobInfo.name" is the correct one